### PR TITLE
fix HMAC

### DIFF
--- a/jak/aes_cipher.py
+++ b/jak/aes_cipher.py
@@ -66,9 +66,8 @@ class AES256Cipher(object):
     def decrypt(self, ciphertext):
         """Decrypts an encrypted secret."""
         signature = ciphertext[-self.SIG_SIZE:]
-        iv_and_data = ciphertext[:-self.SIG_SIZE]
         iv = self.extract_iv(ciphertext=ciphertext)
-        data = iv_and_data[self.BLOCK_SIZE:]
+        data = ciphertext[self.BLOCK_SIZE:-self.SIG_SIZE]
 
         if not self._authenticate(data=data, signature=signature):
             raise WrongKeyException('Wrong key OR the encrypted data has been tampered with. Either way I am aborting...')  # noqa

--- a/jak/aes_cipher.py
+++ b/jak/aes_cipher.py
@@ -9,6 +9,7 @@ import binascii
 from .compat import b
 from Crypto import Random
 from Crypto.Cipher import AES
+from Crypto.Hash import HMAC, SHA512
 from .padding import pad, unpad
 from .exceptions import JakException, WrongKeyException
 
@@ -16,104 +17,81 @@ from .exceptions import JakException, WrongKeyException
 class AES256Cipher(object):
     """AES256 using CBC mode and a 16bit block size."""
 
-    def __init__(self, mode=AES.MODE_CBC):
+    def __init__(self, key, mode=AES.MODE_CBC):
         """You can override the mode if you want, But you had better know
         what you are doing."""
 
         self.cipher = AES
-        self.block_size = AES.block_size
         self.mode = mode
-        self.fingerprint_length = 128
+        self.BLOCK_SIZE = AES.block_size
+        self.SIG_SIZE = SHA512.digest_size
 
-    def _has_integrity(self, key, encrypted_secret, iv):
-        """Validate that the fingerprint (HMAC) will match (aka is the key correct?)"""
-        existing_fingerprint = encrypted_secret[:self.fingerprint_length]
-        new_fingerprint = self._create_integrity_fingerprint(key, iv)
-        return b(new_fingerprint) == existing_fingerprint
+        # We force the key to be 64 hexdigits (nibbles) because we are sadists.
+        key_issue_exception = JakException(
+            ("Key must be 64 hexadecimal [0-f] characters long. \n"
+             "jak recommends you use the 'keygen' command to generate a strong key."))
 
-    def _old_python_create_integrity_fingerprint(self, key, salt):
-        """Used to generate a PBKDF2 HMAC if python version doesn't have a
-        pbkdf2_hmac package built in.
+        # Long enough?
+        if len(key) != 64:
+            raise key_issue_exception
 
-        Only reason we keep this is because of old ubuntu LTS. Come 2018 or so
-        we can probably remove this. And throw a "upgrade your python plz" message instead.
-        https://www.dlitz.net/software/pycrypto/api/current/Crypto.Protocol.KDF-module.html#PBKDF2
-        """
-        from Crypto.Protocol.KDF import PBKDF2
-        from Crypto.Hash import HMAC, SHA512
-
-        def prf(p, s):
-            return HMAC.new(key=p, msg=s, digestmod=SHA512).digest()
-
-        return PBKDF2(password=key, salt=salt, count=10000, prf=prf,
-                      dkLen=int(self.fingerprint_length / 2))
-
-    def _create_integrity_fingerprint(self, key, iv):
-        """Generate a fingerprint during encrypt to check integrity on decrypt
-        uses PBKDF2 (PKCS #5 v2.0)
-
-        for more info see source code here:
-        https://hg.python.org/cpython/file/2.7/Lib/hashlib.py
-        """
         try:
-            from hashlib import pbkdf2_hmac
-        except ImportError:
+            self.key = binascii.unhexlify(key)
+        except TypeError:
 
-            # Must be on python older than 2.7.8...
-            digest = self._old_python_create_integrity_fingerprint(key=b(key), salt=iv)
-        else:
-            digest = pbkdf2_hmac(hash_name='SHA512', password=b(key),
-                                 salt=iv, iterations=10000)
+            # Not all of them are hexadecimals in all likelihood
+            raise key_issue_exception
 
-        fingerprint = binascii.hexlify(digest)
-        return b(fingerprint)
+        # Generate a separate HMAC key. This is (to my understanding) not
+        # strictly necessary.
+        # But was recommended by Thomas Pornin (http://crypto.stackexchange.com/a/8086)
+        self.hmac_key = SHA512.new(data=key).digest()
 
-    def extract_iv(self, encrypted_secret):
+    def _generate_iv(self):
+        """Generates an Initialization Vector (IV).
+
+        This implementation is the currently recommended way of generating an IV
+        in PyCrypto's docs (https://www.dlitz.net/software/pycrypto/api/current/)
+        """
+        return Random.new().read(self.BLOCK_SIZE)
+
+    def _authenticate(self, data, signature):
+        """True if key is correct and data has not been tampered with else False"""
+        return HMAC.new(key=self.hmac_key, msg=data, digestmod=SHA512).digest() == signature
+
+    def extract_iv(self, ciphertext):
         """Extract the IV"""
-        return encrypted_secret[self.fingerprint_length:self.fingerprint_length + self.block_size]
+        return ciphertext[:self.BLOCK_SIZE]
 
-    def decrypt(self, key, encrypted_secret):
+    def decrypt(self, ciphertext):
         """Decrypts an encrypted secret."""
-        key = binascii.unhexlify(key)
-        iv = self.extract_iv(encrypted_secret)
-        if not self._has_integrity(key, encrypted_secret, iv):
-            raise WrongKeyException('Wrong key. Aborting...')
+        signature = ciphertext[-self.SIG_SIZE:]
+        iv_and_data = ciphertext[:-self.SIG_SIZE]
+        iv = self.extract_iv(ciphertext=ciphertext)
+        data = iv_and_data[self.BLOCK_SIZE:]
 
-        # Pop the fingerprint off
-        encrypted_secret = encrypted_secret[self.fingerprint_length:]
+        if not self._authenticate(data=data, signature=signature):
+            raise WrongKeyException('Wrong key OR the encrypted data has been tampered with. Either way I am aborting...')  # noqa
 
         # Setup cipher and perform actual decryption
-        cipher_instance = self.cipher.new(key=key, mode=self.mode, IV=iv)
-        decrypted_secret_and_iv = cipher_instance.decrypt(encrypted_secret)
-        unpadded_decrypted_secret_and_iv = unpad(data=decrypted_secret_and_iv)
-        just_decrypted_secret = unpadded_decrypted_secret_and_iv[self.block_size:]
-        return just_decrypted_secret
+        cipher_instance = self.cipher.new(key=self.key, mode=self.mode, IV=iv)
+        data_padded = cipher_instance.decrypt(ciphertext=data)
+        return unpad(data=data_padded)
 
-    def encrypt(self, key, secret, iv=False):
+    def encrypt(self, plaintext, iv=False):
         """Encrypts a secret"""
 
-        # Convert secret to bytes
-        secret = secret.encode()
-
-        if len(key) != 64:
-            raise JakException(
-                ("Key must be exactly 64 characters long. \n"
-                 "I would recommend you use the keygen command to generate a strong key."))
-
-        # Reduce the 64 hex digits to be 32 bytechars
-        key = binascii.unhexlify(key)
+        # Convert secret to bytes (FIXME: why not just read it as bytes?)
+        plaintext = plaintext.encode()
 
         if not iv:
             iv = self._generate_iv()
 
-        # For checking the integrity of key on decryption
-        fingerprint = self._create_integrity_fingerprint(key, iv)
+        cipher_instance = self.cipher.new(key=self.key, mode=self.mode, IV=iv)
+        plaintext_padded = pad(data=plaintext)
+        encrypted_data = cipher_instance.encrypt(plaintext=plaintext_padded)
 
-        cipher_instance = self.cipher.new(key=key, mode=self.mode, IV=iv)
-        padded_secret = pad(data=secret)
-        encrypted_secret = cipher_instance.encrypt(padded_secret)
-        return fingerprint + iv + encrypted_secret
+        signature = HMAC.new(key=self.hmac_key, msg=encrypted_data, digestmod=SHA512).digest()
 
-    def _generate_iv(self):
-        """Generates an Initialization Vector (IV)."""
-        return Random.new().read(self.block_size)
+        # TODO Add Version
+        return iv + encrypted_data + signature

--- a/jak/crypto_services.py
+++ b/jak/crypto_services.py
@@ -51,7 +51,7 @@ def _restore_from_backup(jwd, filepath, plaintext, aes256_cipher):
 
 
 def write_ciphertext_to_file(filepath, ciphertext):
-    ciphertext = ciphertext.replace('\n', '')
+    ciphertext = ciphertext.replace(b'\n', b'')
     encrypted_chunks = helpers.grouper(ciphertext.decode('utf-8'), 60)
     with open(filepath, 'w', encoding='utf-8') as f:
         f.write(ENCRYPTED_BY_HEADER)

--- a/jak/diff.py
+++ b/jak/diff.py
@@ -90,18 +90,18 @@ cyz>
 >>>>>>> SOMETHING'''
         raise JakException(msg)
 
-    aes256_cipher = AES256Cipher()
+    aes256_cipher = AES256Cipher(key=key)
 
     secrets = []
     try:
-        decrypted = aes256_cipher.decrypt(key=key, encrypted_secret=ugly_local)
+        decrypted = aes256_cipher.decrypt(ciphertext=ugly_local)
     except WrongKeyException as wke:
         raise JakException('LOCAL - {}'.format(wke.__str__()))
     else:
         secrets.append(decrypted.decode('utf-8').rstrip('\n'))
 
     try:
-        decrypted = aes256_cipher.decrypt(key=key, encrypted_secret=ugly_remote)
+        decrypted = aes256_cipher.decrypt(ciphertext=ugly_remote)
     except WrongKeyException as wke:
         raise JakException('REMOTE - {}'.format(wke.__str__()))
     else:

--- a/jak/padding.py
+++ b/jak/padding.py
@@ -5,7 +5,6 @@ Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE for de
 """
 
 import six
-from .compat import b as bulle
 
 
 def pad(data, bs=16):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from jak.compat import b
+
+
+def test_b():
+    assert b('a') == b'a'
+    assert b(b'a') == b'a'
+    assert b(u'a') == b'a'
+    assert b(chr(222)) == b'\xde'

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -8,26 +8,24 @@ example_diff = '''
 - - - Encrypted by jak - - -
 
 <<<<<<< HEAD
-ZDRiM2Q0Yjg0ZTFkNDg3NzRhOTljOWVmYjAxOTE4NmI4Y2UzMTkwNTM5N2Nj
-YjdiYmQyZDU3MjI1MDkwY2ExYmU0NTMzOGYxYTViY2I0YWNlYzdmOWM2OTgz
-NmI5ODkxOWNhNjc5YjdiNGQ5ZDJiMTYyNDFhMzcwMWYxNDVmMWO8ttnsUSsa
-iDNgzDF18NB5RMHOOxjt13wRdV_RHxtZgw==
+Lh_8n6fURQtcJuJ7BYBURAmSbv6eUntMLLeTayRWKGYcxPRqH5GnTDa2JOG3
+L4n1p01vSl4MZQcuTrVCDvTTDYQzTMSEl8NDDjHDFggItCunDkrpCNCxNmw4
+qOd5ONit
 =======
-MGUwMWJhYjgxNDcyMjY2MjhmMzMzNWFlYTMwZDYzYzc5ZDc0NzVhMDc0M2Ji
-ZWUyMDc2NTAyZWM5MTRkMzQ5MmU4NTBlYzY1YjlmYTUwYTdlN2M2MDg3ZTI4
-NGMxNDZjYzJiZDczNGE1ZDEzYmRkZDMyY2IwMDI5Mjc3MWJmOWNXRvFeiNn8
-b6JFJwpATrZOE2srs1sc3p2TM529sw-11Q==
+Xus4rdNzWu-B4MYmo9JNI6zUM7e9XTjqF02OEA7jSG6sHBMjiPEZjp1E6O_t
+wKMDVvGx0xwbtxX9UKnhToR8dYLYXztnW5Q1vNZ4PsjF3SSVR6QUUbGuVjvD
+izhcZbmf
 >>>>>>> f8eb651525b7403aa5ed93c251374ddef8796dee
 '''
 
 
 def test_diff_decrypt():
-    local = 'ZDRiM2Q0Yjg0ZTFkNDg3NzRhOTljOWVmYjAxOTE4NmI4Y2UzMTkwNTM5N2NjYjdiYmQyZDU3MjI1MDkwY2ExYmU0NTMzOGYxYTViY2I0YWNlYzdmOWM2OTgzNmI5ODkxOWNhNjc5YjdiNGQ5ZDJiMTYyNDFhMzcwMWYxNDVmMWO8ttnsUSsaiDNgzDF18NB5RMHOOxjt13wRdV_RHxtZgw=='  # noqa
-    remote = 'MGUwMWJhYjgxNDcyMjY2MjhmMzMzNWFlYTMwZDYzYzc5ZDc0NzVhMDc0M2JiZWUyMDc2NTAyZWM5MTRkMzQ5MmU4NTBlYzY1YjlmYTUwYTdlN2M2MDg3ZTI4NGMxNDZjYzJiZDczNGE1ZDEzYmRkZDMyY2IwMDI5Mjc3MWJmOWNXRvFeiNn8b6JFJwpATrZOE2srs1sc3p2TM529sw-11Q=='  # noqa
-    expected_local = 'API=TRUE'
-    expected_remote = 'BOOM=SHAKA'
+    local = 'Lh_8n6fURQtcJuJ7BYBURAmSbv6eUntMLLeTayRWKGYcxPRqH5GnTDa2JOG3L4n1p01vSl4MZQcuTrVCDvTTDYQzTMSEl8NDDjHDFggItCunDkrpCNCxNmw4qOd5ONit'  # noqa
+    remote = 'Xus4rdNzWu-B4MYmo9JNI6zUM7e9XTjqF02OEA7jSG6sHBMjiPEZjp1E6O_twKMDVvGx0xwbtxX9UKnhToR8dYLYXztnW5Q1vNZ4PsjF3SSVR6QUUbGuVjvDizhcZbmf'  # noqa
+    expected_local = 'SECRET'
+    expected_remote = 'REMOTE_SECRET'
     (dlocal, dremote) = difflib._decrypt(
-        key='1e1862c99f9211a01eebedb00ae1475a1e1862c99f9211a01eebedb00ae1475a',
+        key='2c596b43b406c47d67a620b890da19351c811b643698f9395ab6674cf9f6b7ca',
         local=local,
         remote=remote)
     assert dlocal == expected_local
@@ -39,17 +37,15 @@ def test_extract_merge_conflict_parts():
     result = difflib._extract_merge_conflict_parts(content=example_diff)
     assert len(result) == 5
     assert result[0] == '<<<<<<< HEAD\n'
-    expected = '''ZDRiM2Q0Yjg0ZTFkNDg3NzRhOTljOWVmYjAxOTE4NmI4Y2UzMTkwNTM5N2Nj
-YjdiYmQyZDU3MjI1MDkwY2ExYmU0NTMzOGYxYTViY2I0YWNlYzdmOWM2OTgz
-NmI5ODkxOWNhNjc5YjdiNGQ5ZDJiMTYyNDFhMzcwMWYxNDVmMWO8ttnsUSsa
-iDNgzDF18NB5RMHOOxjt13wRdV_RHxtZgw==
+    expected = '''Lh_8n6fURQtcJuJ7BYBURAmSbv6eUntMLLeTayRWKGYcxPRqH5GnTDa2JOG3
+L4n1p01vSl4MZQcuTrVCDvTTDYQzTMSEl8NDDjHDFggItCunDkrpCNCxNmw4
+qOd5ONit
 '''
     assert result[1] == expected
     assert result[2] == '=======\n'
-    expected = '''MGUwMWJhYjgxNDcyMjY2MjhmMzMzNWFlYTMwZDYzYzc5ZDc0NzVhMDc0M2Ji
-ZWUyMDc2NTAyZWM5MTRkMzQ5MmU4NTBlYzY1YjlmYTUwYTdlN2M2MDg3ZTI4
-NGMxNDZjYzJiZDczNGE1ZDEzYmRkZDMyY2IwMDI5Mjc3MWJmOWNXRvFeiNn8
-b6JFJwpATrZOE2srs1sc3p2TM529sw-11Q==
+    expected = '''Xus4rdNzWu-B4MYmo9JNI6zUM7e9XTjqF02OEA7jSG6sHBMjiPEZjp1E6O_t
+wKMDVvGx0xwbtxX9UKnhToR8dYLYXztnW5Q1vNZ4PsjF3SSVR6QUUbGuVjvD
+izhcZbmf
 '''
     assert result[3] == expected
     assert result[4] == '>>>>>>> f8eb651525b7403aa5ed93c251374ddef8796dee\n'
@@ -71,7 +67,7 @@ def test_smoke_vimdiff(f, lf, rf):
     ('a/real/path', 'env.ext', u'localcontent', u'remotecontent')
 ])
 def test_create_local_remote_diff_files(tmpdir, filepath, name, local, remote):
-    # create a folder for htem to put the files so we dont pollute.
+    # create a folder for them to put the files so we dont pollute.
     test_dir = tmpdir.mkdir('difftests')
     (local_result, remote_result) = difflib._create_local_remote_diff_files(
         test_dir.strpath + '/' + filepath + name,

--- a/tests/test_jak.py
+++ b/tests/test_jak.py
@@ -35,6 +35,8 @@ def test_file_not_found(runner, cmd, filepath):
 
 
 def test_encrypt_smoke(runner):
+    """This one has proven to be an absolute godsend for finding
+    weirdness, especially between python versions."""
     with runner.isolated_filesystem():
         with open('secret.txt', 'w') as f:
             f.write('secret')

--- a/tests/test_jak.py
+++ b/tests/test_jak.py
@@ -52,10 +52,9 @@ def test_encrypt_smoke(runner):
 def test_decrypt_smoke(runner):
     contents = '''- - - Encrypted by jak - - -
 
-ZDVkZTE2ZGMyN2M5MTMzNGNkZWVjMjY0ZWNjNzMyZjAyMzkxOWM0NzMzN2Jm
-MThiMTU2ODg1MzVlY2Y5MjNiNjQ1YmE1Yzc4NTEwMjU1YWRlMWI4YjFlNzU2
-Y2I3MGNlNWZlM2UyZmUzZTI4ZmE5YTA5Zjk2NDBhZmRiOWViZjkemFsYx8cn
-oU05MMawaL5g7zkI_XFFml8NSrXoIgTJ4g=='''
+Ax0zzsNIzeAvO-xtGQ9iLvLY5hTZEvv2drUREskNl650rseMpjnEVhoB4a8H
+PFwYEfNqQhtRC-JOa5uZf4iMzjeTbd4w3ZyX2fDwXr6hV_jCARRTlr38VZNk
+XlpXFy_i'''
     with runner.isolated_filesystem():
 
         with open('secret.txt', 'w') as f:


### PR DESCRIPTION
to, you know, actually use HMAC so we can detect whether someone has tampered witht he encrypted content OR has the wrong key. This actually simplifies the code a fair bit, which is always a good sign.

Huge shout out to @obscurerichard for detecting that the implementation for authenticating was really a glorified KDF.

This is not backwards compatible. If we were past 1.0 this wouldve been a MAJOR version (2.0) update but for now 0.11 seems appropriate.