### PR TITLE
Hopefully fixes issue #36 (asciinema static asset paths dont work in readthedocs)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,9 @@ Lifecycle: 2016-02-01 - current
 
 * **[0.14.1]** HOTFIX: Import of bytestring compatibility function was removed during a merge, and it happened unnoticed. `(commit) <https://github.com/dispel/jak/commit/582dc724fd24d17dbc16b28debf267640116bd0e>`_
 
+* Other:
+   * DOCS: fixed static links for the terminal examples (I guess readthedocs changed something?).
+
 
 0.14
 ----

--- a/docs/guide/usage.rst
+++ b/docs/guide/usage.rst
@@ -54,7 +54,16 @@ Heres a video that explains:
 
 .. raw:: html
 
-   <asciinema-player src="/_static/videos/nosetup.json"></asciinema-player>
+  <!-- If someone has a better way of doing this for readthedocs i'm all ears. -->
+  <div class="asciinema-container--nosetup"></div>
+  <script>
+    var container = document.getElementsByClassName("asciinema-container--nosetup")[0];
+    var href = window.location.href;
+    var basePath = href.substring(href.lastIndexOf('/guide/'), 0);
+    var child = document.createElement('asciinema-player');
+    child.setAttribute('src', basePath + '/_static/videos/nosetup.json');
+    container.appendChild(child);
+  </script>
 
 
 Which jak files should be committed?
@@ -148,4 +157,13 @@ Here is a video for your viewing pleasure.
 
 .. raw:: html
 
-   <asciinema-player src="/_static/videos/diffmerge_short.json"></asciinema-player>
+  <!-- If someone has a better way of doing this for readthedocs i'm all ears. -->
+  <div class="asciinema-container--diffmerge_short"></div>
+  <script>
+    var container = document.getElementsByClassName("asciinema-container--diffmerge_short")[0];
+    var href = window.location.href;
+    var basePath = href.substring(href.lastIndexOf('/guide/'), 0);
+    var child = document.createElement('asciinema-player');
+    child.setAttribute('src', basePath + '/_static/videos/diffmerge_short.json');
+    container.appendChild(child);
+  </script>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,7 +47,16 @@ We also made this video that might be helpful for running through a basic setup 
 
 .. raw:: html
 
-   <asciinema-player src="/_static/videos/quickstart.json"></asciinema-player>
+  <!-- If someone has a better way of doing this for readthedocs i'm all ears. -->
+  <div class="asciinema-container--quickstart"></div>
+  <script>
+    var container = document.getElementsByClassName("asciinema-container--quickstart")[0];
+    var href = window.location.href;
+    var basePath = href.substring(href.lastIndexOf('/'), 0);
+    var child = document.createElement('asciinema-player');
+    child.setAttribute('src', basePath + '/_static/videos/quickstart.json');
+    container.appendChild(child);
+  </script>
 
 
 Stewardship


### PR DESCRIPTION
I am brutally ashamed of this but I could not for the life of me find a way to do this cleanly in sphinx. The main issue is that readthedocs versions the static assets (which is understandable to be fair).

Unfortunatelly this kind of needs to be tested live. but this should be getting us most of the way there.