### PR TITLE
fix sourcetree pre-commit hook

### DIFF
--- a/jak/outputs.py
+++ b/jak/outputs.py
@@ -32,6 +32,10 @@ printf "🌰  ${PURPLE}jak: pre-commit > Encrypting files listed in jakfile.${NC
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 
+# Not thrilled about this since it is OS specific but certain git apps
+# (in this instance SourceTree) couldn't find jak in the pre-commit hook.
+export PATH=/usr/local/bin:$PATH
+
 
 # Encrypt any staged files that are protected by jak
 python .git/hooks/jak.pre-commit.py

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,9 @@ setup(
     },
     classifiers=[
         # As from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'Development Status :: 2 - Pre-Alpha',
+        # 'Development Status :: 2 - Pre-Alpha',
         # 'Development Status :: 3 - Alpha',
-        # 'Development Status :: 4 - Beta',
+        'Development Status :: 4 - Beta',
         # 'Development Status :: 5 - Production/Stable',
         # 'Development Status :: 6 - Mature',
         # 'Development Status :: 7 - Inactive',

--- a/ship.sh
+++ b/ship.sh
@@ -1,0 +1,15 @@
+# If this is your first time or it's just been a while:
+# https://packaging.python.org/guides/using-testpypi/
+# https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi
+
+# rm -rf dist/
+# python 2
+# python setup.py bdist_wheel
+# switch to python 3 and run it again
+# python setup.py bdist_wheel
+
+# Test
+twine upload -r testpypi --config-file .pypirc dist/*
+
+# Prod
+twine upload --config-file .pypirc dist/*


### PR DESCRIPTION
wasnt working because it couldn't find the jak command. it must be running in a very slimmed down shell, so i add the jak system directory to the environment in the pre-commit hook.

This does include some other odds and ends that do not edit functionality.