### PR TITLE
updating (removing from CI) pypy support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
   - pip install .
   - pip install -r requirements_dev.txt
 
-script: pytest
+script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy"
+  # - "pypy"
 
 install:
   - pip install .
   - pip install -r requirements_dev.txt
 
-script: py.test
+script: pytest

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,16 +76,16 @@ Table of contents
    guide/commands
    guide/contributor
    security
-   support
+   supported-platforms
    changelog
 
 
 .. _support_short:
 
-Support
--------
+Supported platforms
+-------------------
 
-jak works if you have a modern Python (2.7-3.5) installed on a `*nix <https://en.wikipedia.org/wiki/Unix-like>`_ system.
+jak works if you have a modern Python (2.7-3.6) installed on a `*nix <https://en.wikipedia.org/wiki/Unix-like>`_ system.
 
 :ref:`You can read about it in excrutiating detail here. <support_detailed>`
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ jak is a tool for encrypting files. jak works extra well if used in a git reposi
 
 .. warning::
 
-   jak is not ready yet. You are welcome to try jak, but we highly recommend against using it on any actual secrets yet!
+  jaks encryption works. But use is under your own responsibility. I would highly recommend you take the auto-commit hook on a dry run before actually relying on it.
 
 
 

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -9,12 +9,15 @@ Python Support
 
 jak is explicitly tested on Pythons:
 
-- 2.7.7 (It is probably safe to assume jak works for 2.7.7 - 2.7.13)
+- 2.7 (It is probably safe to assume jak works for 2.7.7 - 2.7.13)
 - 3.3
 - 3.4
 - 3.5
 - 3.6
-- `PyPy <http://pypy.org/>`_
+
+Works but CI fails:
+
+- `PyPy <http://pypy.org/>`_. (It works just fine locally but travis seems to have trouble with it, so we removed it from CI for now. The issue is that pycrypto fails to install under it, and pycrypto seems to explicitly state that they dont work with pypy. Nonetheless, we've gotten this working on our machines just fine...)
 
 Planned but not tested yet, but hopefully work:
 

--- a/docs/supported-platforms.rst
+++ b/docs/supported-platforms.rst
@@ -1,11 +1,11 @@
 .. _support_detailed:
 
 
-Support
-=======
+Supported platforms
+===================
 
-Python Support
---------------
+Python
+------
 
 jak is explicitly tested on Pythons:
 
@@ -36,7 +36,7 @@ For all you Python 2.7 lunatics out there that means when `this clock reaches ze
 It is however likely that even without explicitly testing for it the 3.X versions will continue to work just fine even after we officially stop supporting them.
 
 
-OS Support
-----------
+OS
+--
 
 We believe jak should work well on most `*nix <https://en.wikipedia.org/wiki/Unix-like>`_ systems. But is mainly developed on Ubuntu and tested on Ubuntu and macOS.


### PR DESCRIPTION
What brought this on was that travis CI fails for pypy due to pycrypto installation step.

updating that support for pypy is maybe a bit more strenuous than we first assumed.