### PR TITLE
[1.0.0] Deprecate old pythons and confirm everything works for newer pythons.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: false
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
-  # - "pypy"
+  - "3.7"
+  - "3.8"
+  - "3.9"
+  - "pypy3"
 
 install:
   - pip install .

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ By sharing a key through some other means all developers can encrypt and decrypt
 
 For a more thorough introduction you should [read the documentation.](https://jak.readthedocs.io).
 
-jak currently works for *nix type systems such as macOS or ubuntu. We are working on windows compatibility.
-
-**IMPORTANT!! JAK IS NOT READY FOR PRODUCTION USE YET!!**
+jak currently works for *nix type systems such as macOS or ubuntu.
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jak
 
 [![jak package on pypi](https://img.shields.io/pypi/v/jak.svg)](https://pypi.python.org/pypi/jak)
-[![travis-ci](https://travis-ci.org/dispel/jak.svg?branch=master)](https://travis-ci.org/dispel/jak)
+[![Build Status](https://travis-ci.com/dispel/jak.svg?branch=master)](https://travis-ci.com/dispel/jak)
 [![supported python versions](https://img.shields.io/pypi/pyversions/jak.svg)](https://pypi.python.org/pypi/jak)
 
 jak can encrypt and decrypt files. The standard example is of a ``.env`` file with secrets in it inside of a git repository.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,56 +9,38 @@ export DEBIAN_FRONTEND=noninteractive
 
 # Let's install some Snakes!
 sudo apt-get update
-sudo add-apt-repository ppa:fkrull/deadsnakes -y
-sudo apt-get update
+sudo add-apt-repository ppa:deadsnakes/ppa -y
 sudo apt-get install build-essential libssl-dev libffi-dev -y
-sudo apt-get install python-pip git -y
+# sudo apt-get install python-pip git -y
 
 # Update pip
-sudo pip install --upgrade pip
+# sudo pip install --upgrade pip
 
-# Install all the snakes.
-sudo apt-get install python3-dev python-dev python3.4 python3.4-dev python3.5-dev python3.6 python3.6-dev pypy pypy-dev -y --allow-unauthenticated
-
-# Virtualenvs for quickly switching between python 2 and 3
-sudo pip install virtualenvwrapper
-
-# Add ye olden virtualenvwrapper settings to the .profile and load them in.
-sed -i "$ a # Virtualenvwrapper settings" /home/ubuntu/.profile
-sed -i "$ a export WORKON_HOME=/home/ubuntu/.virtualenvs" /home/ubuntu/.profile
-sed -i "$ a export PROJECT_HOME=/home/ubuntu/Devel" /home/ubuntu/.profile
-sed -i "$ a source /usr/local/bin/virtualenvwrapper.sh" /home/ubuntu/.profile
-source /home/ubuntu/.profile
+# Install all the snakes. (3.8 is already in Ubuntu 20 (Focal))
+sudo apt install python3.8-venv python3.8-dev python3.9 python3.9-venv python3.9-dev python3.7 python3.7-dev python3.7-venv python3.6 python3.6-dev python3.6-venv pypy3 pypy3-dev -y
 
 # Pop into the folder where jak lives
 cd /vagrant
 
-# Create our two virtualenvironments
-# switch between them with "workon py27" for example.
-mkvirtualenv py27
-mkvirtualenv -p /usr/bin/pypy pypy
-mkvirtualenv -p /usr/bin/python3.6 py36
+# Virtual environments for python 3.9 and 3.8
+# You can use similar commands if you want to test other versions or pypy.
+python3.9 -m venv ~/venvs/py39
+python3.8 -m venv ~/venvs/py38
+pypy3 -m venv ~/venvs/pypy3
 
-# We should now be in py36 so let's install our dependencies.
+# Activate 3.9 virtualenv
+source ~/venvs/py39/bin/activate
+
+# We should now be in py39 so let's install our dependencies.
 pip install --editable .
 pip install -r requirements_dev.txt
-
-# py27
-workon py27
-pip install --editable .
-pip install -r requirements_dev.txt
-
-# # PyPy
-# workon pypy
-# pip install --editable .
-# pip install -r requirements_dev.txt
 
 echo Finished custom provisioning!
 SCRIPT
 
 Vagrant.configure(2) do |config|
 
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/focal64"
 
   # config.vm.provider "virtualbox" do |vb|
   #   # vb.memory = "2048"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,22 +11,20 @@ export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update
 sudo add-apt-repository ppa:deadsnakes/ppa -y
 sudo apt-get install build-essential libssl-dev libffi-dev -y
-# sudo apt-get install python-pip git -y
 
-# Update pip
-# sudo pip install --upgrade pip
-
-# Install all the snakes. (3.8 is already in Ubuntu 20 (Focal))
+# Install all the snakes. (except 3.8 which is already in Ubuntu 20.04 (Focal))
 sudo apt install python3.8-venv python3.8-dev python3.9 python3.9-venv python3.9-dev python3.7 python3.7-dev python3.7-venv python3.6 python3.6-dev python3.6-venv pypy3 pypy3-dev -y
 
 # Pop into the folder where jak lives
 cd /vagrant
 
-# Virtual environments for python 3.9 and 3.8
+# Virtual environments for python 3.9
 # You can use similar commands if you want to test other versions or pypy.
 python3.9 -m venv ~/venvs/py39
-python3.8 -m venv ~/venvs/py38
-pypy3 -m venv ~/venvs/pypy3
+
+# Heres how to make more venvs if you want for dev.
+# python3.8 -m venv ~/venvs/py38
+# pypy3 -m venv ~/venvs/pypy3
 
 # Activate 3.9 virtualenv
 source ~/venvs/py39/bin/activate

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,15 +8,15 @@ Changelog
 1.0 (Young Whippersnapper)
 --------------------------
 
-Hi Everyone! It's been a hot minute, we went through a pandemic and some other stuff happened. It's time to throw away the old and bring on the new. While no security issues have been found the PyCrypto library seems to have gone the way of the dinosaurs. Therefor we are switching jak to the excellent replacement pycryptome
+Hi Everyone! It‘s been a hot minute, we went through a pandemic and some other stuff happened. It‘s time to throw away the old and bring on the new. While no security issues have been found the PyCrypto library seems to have gone the way of the dinosaurs. Therefor we are switching jak to the excellent replacement `(PyCryptodome to) <https://pycryptodome.readthedocs.io>` and updating which python versions jak supports to the `(currently supported ones) <https://www.python.org/downloads/>` (3.6 - 3.9 and pypy3).
 
-Lifecycle: 2021-08-X
+Lifecycle: 2021-08-X (UNRELEASED)
 
-* **[1.1.0]** DEPENDENCY: Switch from `(PyCryptodome to) <https://pycryptodome.readthedocs.io>` `(cryptography) <https://cryptography.io/en/latest/>` since it just seems more vetted.
 * **[1.0.0]** MAJOR:
   * Drop support for 2.7, 3.4, 3.5 and pypy. Add support for 3.6, 3.7, 3.8, 3.9.
   * Update documentation to reflect version update and change of supported versions.
   * Switch from PyCrypto to PyCryptodome. May well switch to `(cryptography) <https://cryptography.io/en/latest/>` in a
+  * TODO DEPRECATION: Remove the compat layer used to support Python 2.
 
 
 0.14.6

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,9 +8,15 @@ Changelog
 1.0 (Young Whippersnapper)
 --------------------------
 
-Lifecycle: Not released yet.
+Hi Everyone! It's been a hot minute, we went through a pandemic and some other stuff happened. It's time to throw away the old and bring on the new. While no security issues have been found the PyCrypto library seems to have gone the way of the dinosaurs. Therefor we are switching jak to the excellent replacement pycryptome
 
-1.0.0 Will be assigned when we have verified that the encryption is absolutely stable AND we believe the risk of us accidentally deleting peoples secrets is < 0.0001%. In practice this means better unit testing and talking to 2-3 more cryptography experts (especially outside of Dispel). Are you such an expert? Get in touch! cdilorenzo@dispel.io.
+Lifecycle: 2021-08-X
+
+* **[1.1.0]** DEPENDENCY: Switch from `(PyCryptodome to) <https://pycryptodome.readthedocs.io>` `(cryptography) <https://cryptography.io/en/latest/>` since it just seems more vetted.
+* **[1.0.0]** MAJOR:
+  * Drop support for 2.7, 3.4, 3.5 and pypy. Add support for 3.6, 3.7, 3.8, 3.9.
+  * Update documentation to reflect version update and change of supported versions.
+  * Switch from PyCrypto to PyCryptodome. May well switch to `(cryptography) <https://cryptography.io/en/latest/>` in a
 
 
 0.14.6

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@
 #
 import os
 import sys
+from jak import __version__, __version_full__
 sys.path.insert(0, os.path.abspath('..'))
 
 
@@ -47,13 +48,12 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'jak'
-copyright = '2017, Dispel, LLC'
+copyright = '2021, Dispel, LLC'
 author = 'Dispel, LLC'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-from jak import __version__, __version_full__
 
 # The short X.Y version.
 version = __version__
@@ -82,7 +82,8 @@ todo_include_todos = False
 
 # -- Options for HTML output ----------------------------------------------
 
-# on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
+# on_rtd is whether we are on readthedocs.org, this line of code grabbed from
+# docs.readthedocs.org
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if not on_rtd:  # only import and set the theme if we're building docs locally

--- a/docs/guide/contributor.rst
+++ b/docs/guide/contributor.rst
@@ -76,15 +76,13 @@ Once your branch or fork looks good make a PR and one of the stewards will take 
 Alerts
 ------
 
-It currently (2017-01-25) appears that tox will NOT run from Python 3.6 due to urrlib3 not existing. So run your tox from a different base Python environment for now.
-
-Also PyPy tests don't seem to run in tox either, I recommend checking out the virtualenv (``workon pypy``) and running them straight with ``pytest``. If someone could fix this, it would be much appreciated.
+No alerts. Everything seems to be working fine.
 
 
 Future versions
 ---------------
 
-0 - 10 are the formative years. If we get past them (which seems frankly highly unlikely) we will start a new naming scheme. We use `semantic versioning <http://semver.org/>`_ so the only time we shift the first number would be if we make backwards incompatible changes. The exception to this is 1.0 which will be assigned when Chris DiLorenzo thinks jak is (1) verified to be secure and (2) have no known bugs and (3) have decent tests for it's core functionality.
+0 - 10 are the formative years. If we get past them (which seems frankly highly unlikely) we will start a new naming scheme. We use `semantic versioning <http://semver.org/>`_ so the only time we shift the first number would be if we make backwards incompatible changes. The exception to this is 1.0 which will be assigned when Chris DiLorenzo thinks jak is (1) verified to be secure and (2) have no known bugs and (3) have decent tests for it‘s core functionality.
 
 .. sourcecode:: text
 

--- a/docs/guide/contributor.rst
+++ b/docs/guide/contributor.rst
@@ -30,10 +30,8 @@ Developer machine setup
   # This is where the project files are mirrorer on the virtual machine
   cd /vagrant
 
-  # Choose a virtualenv to work on (see virtualenvwrapper docs)
-  # It is recommended you use the py27 environment for development and
-  # then switching to py35 when you have an issue in Python 3.
-  workon py27
+  # Activate virtualenv
+  source ~/venvs/py39/bin/activate
 
   # Run tests for multiple Python versions (see tox.ini)
   tox
@@ -90,11 +88,11 @@ Future versions
 
 .. sourcecode:: text
 
-  0.X Troubled Toddler        <-- CURRENT
-  1.X Young Whippersnapper
+  0.X Troubled Toddler
+  1.X Young Whippersnapper  <-- CURRENT
   2.X Teenage Wasteland
-  3.X Highschool Sweetheart
-  4.X Wannabee Scientist
+  3.X High school Sweetheart
+  4.X Wannabe Scientist
   5.X Jaded Hipster
   6.X Midlife Maniac
   7.X Dorky Parent

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -16,17 +16,17 @@ Hopefully this image will be helpful in having you understand how the encryption
 Encryption
 ----------
 
-jak uses the **PyCrypto** implementation of **AES256** running in **CBC-MODE** for its encryption. What makes AES be 256 is the key space of the key you use. For 256-bit you should have a 32 byte key that is as random as possible. 1 byte is 8 bits so 256 / 8 = 32. This gives you a key space of 2^32.
+jak uses the **PyCryptodome** implementation of **AES256** running in **CBC-MODE** for its encryption. What makes AES be 256 is the key space of the key you use. For 256-bit you should have a 32 byte key that is as random as possible. 1 byte is 8 bits so 256 / 8 = 32. This gives you a key space of 2^32.
 
-jak requires a 64 character hexadecimal key. It can :ref:`generate it for you. <keygen_cmd>`  It should look something like this ``b30259425d7e5a8b4858f72948d7a232142c292997d6431efaa6a02d7a866b03``. To keep it readable we are actually representing the bytes as hexdigits, 2 hex digits are 1 byte of complexity. ``b3 02 59 42`` is 4 bytes. Therefore the 64 character is key 32 bytes. jak generates this key from **/dev/urandom** (``binascii.hexlify(os.urandom(32))``).
+jak requires a 64 character hexadecimal key. It can :ref:`generate it for you. <keygen_cmd>`  It should look something like this ``b30259425d7e5a8b4858f72948d7a232142c292997d6431efaa6a02d7a866b03``. To keep it readable we are actually representing the bytes as hexdigits, 2 hex digits are 1 byte of complexity. ``b3 02 59 42`` is 4 bytes. Therefore the 64 character key is 32 bytes. jak generates this key from **/dev/urandom** (``binascii.hexlify(os.urandom(32))``).
 
 CBC-MODE requires padding. jak uses **PKCS#7** padding. In plain English that means that jak pads the plaintext secret to be a multiple of the block size (defaults to 16) by adding padding where each character is a number equal to the amount of padding. The previous sentence might be tricky, so here is an example to clarify: ``pad('aaaaaaaaaaaaa') returns 'aaaaaaaaaaaaa\x03\x03\x03'``.
 
-CBC-MODE also requires an **Initialization Vector (IV)**. jak generates it using the **Fortuna (PRNG)** as implemented by **PyCrypto**.
+CBC-MODE also requires an **Initialization Vector (IV)**. jak generates it using the **Fortuna (PRNG)** as implemented by **PyCryptodome**.
 
 Further reading:
 
-* https://www.pycrypto.org
+* https://pycryptodome.readthedocs.io/en/latest/
 * https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
 * https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_Block_Chaining_.28CBC.29
 * https://en.wikipedia.org/wiki/Key_space_(cryptography)
@@ -58,13 +58,11 @@ Further reading:
 Obtaining randomness
 --------------------
 
-The random values jak generates are the **key** and the **IV**. Measuring randomness is hard if not impossible and there seems to be a great deal of differing opinions about what is a good source. The TL;DR seems to be that /dev/urandom and Fortuna are sufficiently random. But please educate yourself, it's a really interesting subject. Here are some good links to get you started.
+The random values jak generates are the **key** and the **IV**. Measuring randomness is hard if not impossible and there seems to be a great deal of differing opinions about what is a good source. The TL;DR seems to be that /dev/urandom and Fortuna are sufficiently random. But please educate yourself, it‘s a really interesting subject. Here are some good links to get you started.
 
-* https://docs.python.org/3.5/library/os.html#os.urandom
-* https://docs.python.org/2.7/library/os.html#os.urandom
+* https://docs.python.org/3.9/library/os.html#os.urandom
 * https://sockpuppet.org/blog/2014/02/25/safely-generate-random-numbers/
 * http://www.2uo.de/myths-about-urandom/
-* https://github.com/dlitz/pycrypto/blob/master/lib/Crypto/Random/__init__.py
 
 
 Final thoughts

--- a/docs/supported-platforms.rst
+++ b/docs/supported-platforms.rst
@@ -9,30 +9,21 @@ Python
 
 jak is explicitly tested on Pythons:
 
-- 2.7 (It is probably safe to assume jak works for 2.7.7 - 2.7.X, where X > 7)
-- 3.4
-- 3.5
 - 3.6
+- 3.7
+- 3.8
+- 3.9
+- PyPy3
 
 Works but CI fails:
 
-- `PyPy <http://pypy.org/>`_. (It works just fine locally but travis seems to have trouble with it, so we removed it from CI for now. The issue is that pycrypto fails to install under it, and pycrypto seems to explicitly state that they dont work with pypy. Nonetheless, we've gotten this working on our machines just fine...)
-
-Planned but not tested yet, but hopefully work:
-
-- PyPy3
+- `PyPy3 <http://pypy.org/>`_. (It works just fine locally but travis seems to have trouble with it, so we removed it from CI for now. The issue is that pycrypto fails to install under it, and pycrypto seems to explicitly state that they dont work with pypy. Nonetheless, we've gotten this working on our machines just fine...)
 
 jak follows the `Python end of support dates <https://docs.python.org/devguide/index.html#branchstatus>`_, which in practice means that support ends on the following dates:
 
-- 3.4 (PEP 429) support ends 2019-03-16
-- 2.7 (PEP 373) support ends 2020-01-01
-- 3.5 (PEP 478) support ends 2020-09-13
 - 3.6 (PEP 494) support ends 2021-12-23
-
-For all you Python 2.7 lunatics out there that means when `this clock reaches zero <https://pythonclock.org/>`_ we drop 2.7 in the name of `courage <http://www.theverge.com/2016/9/7/12838024/apple-iphone-7-plus-headphone-jack-removal-courage>`_, progress and maintaining a clean codebase. It is my understanding that dropping 2.7 may implicitly mean dropping PyPy as well, which may sway this decision, since jak is a sucker for scrappy whippersnappers.
-
-It is however likely that even without explicitly testing for it the 3.X versions will continue to work just fine even after we officially stop supporting them.
-
+- 3.7 (PEP 537) support ends 2023-06-27
+- 3.8 (PEP 569) support ends 2024-10
 
 OS
 --

--- a/docs/supported-platforms.rst
+++ b/docs/supported-platforms.rst
@@ -15,17 +15,13 @@ jak is explicitly tested on Pythons:
 - 3.9
 - PyPy3
 
-Works but CI fails:
-
-- `PyPy3 <http://pypy.org/>`_. (It works just fine locally but travis seems to have trouble with it, so we removed it from CI for now. The issue is that pycrypto fails to install under it, and pycrypto seems to explicitly state that they dont work with pypy. Nonetheless, we've gotten this working on our machines just fine...)
-
 jak follows the `Python end of support dates <https://docs.python.org/devguide/index.html#branchstatus>`_, which in practice means that support ends on the following dates:
 
 - 3.6 (PEP 494) support ends 2021-12-23
 - 3.7 (PEP 537) support ends 2023-06-27
 - 3.8 (PEP 569) support ends 2024-10
 
-OS
+Operating Systems
 --
 
 We believe jak should work well on most `*nix <https://en.wikipedia.org/wiki/Unix-like>`_ systems. But is mainly developed on Ubuntu and tested on Ubuntu and macOS.

--- a/jak/__init__.py
+++ b/jak/__init__.py
@@ -7,11 +7,11 @@ About versioning
 ----------------
 Past, current and future versions.
 
-0.X Troubled Toddler        <-- CURRENT
-1.X Young Whippersnapper
+0.X Troubled Toddler
+1.X Young Whippersnapper  <-- CURRENT
 2.X Teenage Wasteland
-3.X Highschool Sweetheart
-4.X Wannabee Scientist
+3.X High school Sweetheart
+4.X Wannabe Scientist
 5.X Jaded Hipster
 6.X Midlife Maniac
 7.X Dorky Parent
@@ -20,9 +20,6 @@ Past, current and future versions.
 10.X Wizened Witch
 
 If in doubt about how version should increase see: http://semver.org/
-The exception is version 1.X which is when we are saying that we are comfortable
-with people using it. I Don't care what incompatible API changes happen during 0.X
-it is NOT 1.X until we are 99.9 percent sure it is secure.
 
 Semantic Versioning Cheatsheet
 ------------------------------
@@ -31,9 +28,10 @@ MAJOR version when you make incompatible API changes,
 MINOR version when you add functionality in a backwards-compatible manner, and
 PATCH version when you make backwards-compatible bug fixes.
 
-Copyright 2018 Dispel, LLC
-Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE for details.
+Copyright 2021 Dispel, LLC
+Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE
+for details.
 """
 
-__version__ = '0.14.6'
-__version_full__ = "Jak v{0} ({1})".format(__version__, 'Troubled Toddler')
+__version__ = '1.0.0'
+__version_full__ = "Jak v{0} ({1})".format(__version__, 'Young Whippersnapper')

--- a/jak/aes_cipher.py
+++ b/jak/aes_cipher.py
@@ -51,9 +51,8 @@ class AES256Cipher(object):
 
     def _generate_iv(self):
         """Generates an Initialization Vector (IV).
-
-        This implementation is the currently recommended way of generating an IV
-        in PyCrypto's docs (https://www.dlitz.net/software/pycrypto/api/current/)
+        https://github.com/Legrandin/pycryptodome/blob/master/lib/Crypto/Random/__init__.py
+        Seems to be making use of os.urandom.
         """
         return Random.new().read(self.BLOCK_SIZE)
 
@@ -61,8 +60,8 @@ class AES256Cipher(object):
         """True if key is correct and data has not been tampered with else False"""
         new_mac = hmac.new(key=self.hmac_key, msg=data, digestmod=SHA512).digest()
 
-        # It is important to compare them like this instead of using '==' to prevent
-        # timing attacks
+        # It is important to compare them like this instead of using '=='
+        # to prevent timing attacks
         return hmac.compare_digest(new_mac, signature)
 
     def extract_iv(self, ciphertext):
@@ -113,7 +112,10 @@ class AES256Cipher(object):
         version = self._extract_version(ciphertext=ciphertext)
 
         if self._need_old_decrypt_function(version):
-            return self._use_old_decrypt_function(version=version, ciphertext=ciphertext)
+            return self._use_old_decrypt_function(
+                version=version,
+                ciphertext=ciphertext
+            )
 
         signature = self._extract_signature(ciphertext=ciphertext)
         iv = self.extract_iv(ciphertext=ciphertext)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 Documentation: https://jak.readthedocs.io
 
-Copyright 2018 Dispel, LLC
+Copyright 2021 Dispel, LLC
 
 Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE for details.
 """
@@ -34,7 +34,7 @@ setup(
     platforms='any',
     install_requires=[
         'click>=6.6',
-        'pycrypto>=2.6.1',
+        'pycryptodome>=3.10.1',
         'six>=1.10.0'
     ],
     entry_points={
@@ -44,8 +44,7 @@ setup(
     },
     classifiers=[
         # As from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'Development Status :: 4 - Beta',
-        # 'Development Status :: 5 - Production/Stable',
+        'Development Status :: 5 - Production/Stable',
         # 'Development Status :: 6 - Mature',
         # 'Development Status :: 7 - Inactive',
         'Environment :: Console',
@@ -57,10 +56,10 @@ setup(
         'Operating System :: Unix',
         # 'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: PyPy'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
             'jak = jak.app:main',
         ],
     },
+    python_requires='>=3.6',
     classifiers=[
         # As from http://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 5 - Production/Stable',

--- a/tests/test_jak.py
+++ b/tests/test_jak.py
@@ -22,7 +22,7 @@ def test_version(runner, version_flag):
     result = runner.invoke(jak, [version_flag])
     assert not result.exception
     assert result.exit_code == 0
-    assert '(Troubled Toddler)' in result.output.strip()
+    assert '(Young Whippersnapper)' in result.output.strip()
 
 
 @pytest.mark.parametrize('cmd, filepath', [

--- a/tox.ini
+++ b/tox.ini
@@ -6,27 +6,25 @@
 # However, any kind of CI SHOULD run with all of these environments
 # Barring that please run with all environments before committing.
 envlist=
-    py27
-    py34
-    py35
     py36
-    pypy
-    # pypy3 (todo)
+    py37
+    py38
+    py39
+    pypy3
     # jython (todo)
-    # flake8
 
 [testenv]
 usedevelop=true
 commands=py.test --cov jak {posargs}
 deps=
     lowest: click==6.6
-    lowest: pycrypto==2.6.1
+    lowest: pycryptodome==3.10.1
     lowest: six==1.10.0
 
     -rrequirements_dev.txt
 
 [testenv:flake8]
-basepython = python2.7
+basepython = python3.9
 deps=
     -rrequirements.txt
     -rrequirements_dev.txt


### PR DESCRIPTION
fixes https://github.com/dispel/jak/issues/59

Confirms that it works on newer pythons (by drop in replacing pycrypto with pycryptodome). Drops support for older pythons (2.7, 3.4, 3.5 and pypy)