### PR TITLE
Upgrade Python syntax with pyupgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
   - pip install .
   - pip install -r requirements_dev.txt
 
-script: py.test
+script: pytest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # jak documentation build configuration file, created by
 # sphinx-quickstart on Mon Jan 9 13:37:00 2017.

--- a/jak/__init__.py
+++ b/jak/__init__.py
@@ -34,4 +34,4 @@ for details.
 """
 
 __version__ = '1.0.0'
-__version_full__ = "Jak v{0} ({1})".format(__version__, 'Young Whippersnapper')
+__version_full__ = "Jak v{} ({})".format(__version__, 'Young Whippersnapper')

--- a/jak/aes_cipher.py
+++ b/jak/aes_cipher.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Copyright 2021 Dispel, LLC
 Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE for details.
@@ -14,7 +12,7 @@ from .padding import pad, unpad
 from .exceptions import JakException, WrongKeyException
 
 
-class AES256Cipher(object):
+class AES256Cipher:
     """AES256 using CBC mode and a 16bit block size."""
 
     def __init__(self, key, mode=AES.MODE_CBC):
@@ -29,8 +27,8 @@ class AES256Cipher(object):
 
         # We force the key to be 64 hexdigits (nibbles) because we are sadists.
         key_issue_exception = JakException(
-            ("Key must be 64 hexadecimal [0-f] characters long. \n"
-             "jak recommends you use the 'keygen' command to generate a strong key."))
+            "Key must be 64 hexadecimal [0-f] characters long. \n"
+             "jak recommends you use the 'keygen' command to generate a strong key.")
 
         # Long enough?
         if len(key) != 64:
@@ -102,7 +100,7 @@ class AES256Cipher(object):
         # Haven't upgraded our encryption since we added ciphertext versioning.
         # When we do we will replace this with a switch statement selecting old
         # Decryption methods.
-        raise Exception('FATAL: No one should end up here.... VERSION: {}, C: {}'.format(version, ciphertext))
+        raise Exception(f'FATAL: No one should end up here.... VERSION: {version}, C: {ciphertext}')
 
     def decrypt(self, ciphertext):
         """Decrypts a ciphertext secret"""

--- a/jak/app.py
+++ b/jak/app.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Copyright 2021 Dispel, LLC
 Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE for details.
@@ -74,7 +73,7 @@ def start():
     jwd = helpers.get_jak_working_directory()
     click.echo(start_logic.create_jakfile(jwd=jwd))
 
-    if not os.path.exists('{}/.git'.format(jwd)):
+    if not os.path.exists(f'{jwd}/.git'):
         msg = helpers.two_column('Is this a git repository?', 'Nope!')
         msg += '\n  jak says: I work great with git, but you do you.'
         click.echo(msg)

--- a/jak/crypto_services.py
+++ b/jak/crypto_services.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Copyright 2021 Dispel, LLC
 Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE for details.
@@ -7,12 +5,11 @@ Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE for de
 
 import base64
 import binascii
-from io import open
 from . import helpers
 from .aes_cipher import AES256Cipher
 from .exceptions import JakException, WrongKeyException
 
-ENCRYPTED_BY_HEADER = u'- - - Encrypted by jak - - -\n\n'
+ENCRYPTED_BY_HEADER = '- - - Encrypted by jak - - -\n\n'
 
 
 def _read_file(filepath):
@@ -20,11 +17,11 @@ def _read_file(filepath):
     try:
         with open(filepath, 'rb') as f:
             contents = f.read()
-    except IOError:
-        raise JakException("Sorry I can't find the file: {}".format(filepath))
+    except OSError:
+        raise JakException(f"Sorry I can't find the file: {filepath}")
 
     if len(contents) == 0:
-        raise JakException('The file "{}" is empty, aborting...'.format(filepath))
+        raise JakException(f'The file "{filepath}" is empty, aborting...')
 
     return contents
 
@@ -64,7 +61,7 @@ def encrypt_file(jwd, filepath, key, **kwargs):
     plaintext = _read_file(filepath=filepath)
 
     if bytes(ENCRYPTED_BY_HEADER, 'utf-8') in plaintext:
-        raise JakException('I already encrypted the file: "{}".'.format(filepath))
+        raise JakException(f'I already encrypted the file: "{filepath}".')
 
     aes256_cipher = AES256Cipher(key=key)
 
@@ -80,7 +77,7 @@ def encrypt_file(jwd, filepath, key, **kwargs):
         ciphertext = base64.urlsafe_b64encode(ciphertext_ugly)
 
     write_ciphertext_to_file(filepath=filepath, ciphertext=ciphertext)
-    return '{} - is now encrypted.'.format(filepath)
+    return f'{filepath} - is now encrypted.'
 
 
 def decrypt_file(filepath, key, jwd, **kwargs):
@@ -115,9 +112,9 @@ def decrypt_file(filepath, key, jwd, **kwargs):
     try:
         decrypted_secret = aes256_cipher.decrypt(ciphertext=ciphertext)
     except WrongKeyException as wke:
-        raise JakException('{} - {}'.format(filepath, wke.__str__()))
+        raise JakException(f'{filepath} - {wke.__str__()}')
 
     with open(filepath, 'wb') as f:
         f.write(decrypted_secret)
 
-    return '{} - is now decrypted.'.format(filepath)
+    return f'{filepath} - is now decrypted.'

--- a/jak/decorators.py
+++ b/jak/decorators.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
-
 """
 Copyright 2021 Dispel, LLC
 Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE for details.
 """
 
 import os
-from io import open
 from . import helpers
 from functools import wraps
 from .exceptions import JakException
@@ -54,7 +51,7 @@ def read_jakfile(f):
     def wrapper(*args, **kwargs):
         try:
             kwargs['jakfile_dict'] = helpers.read_jakfile_to_dict()
-        except IOError:
+        except OSError:
             kwargs['jakfile_dict'] = {}
         except ValueError as ve:
             raise JakException("Your jakfile has malformed syntax (probably).")
@@ -107,10 +104,10 @@ def select_key_logic(key=None, keyfile=None, jakfile_dict=None):
 
     if keyfile:
         try:
-            with open(keyfile, 'rt', encoding='utf-8') as f:
+            with open(keyfile, encoding='utf-8') as f:
                 key = f.read()
-        except IOError:
-            raise JakException("Sorry I can't find the key file: {}".format(keyfile))
+        except OSError:
+            raise JakException(f"Sorry I can't find the key file: {keyfile}")
         else:
             key = key.replace('\n', '')
             return key
@@ -118,10 +115,10 @@ def select_key_logic(key=None, keyfile=None, jakfile_dict=None):
     # At this point they must have supplied a keyfile value in their jakfile
     filepath = jakfile_dict['keyfile']
     try:
-        with open(filepath, 'rt', encoding='utf-8') as f:
+        with open(filepath, encoding='utf-8') as f:
             key = f.read()
-    except IOError:
-        raise JakException("Sorry I can't find the key file: {}".format(filepath))
+    except OSError:
+        raise JakException(f"Sorry I can't find the key file: {filepath}")
     else:
         key = key.replace('\n', '')
         return key

--- a/jak/diff.py
+++ b/jak/diff.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Copyright 2021 Dispel, LLC
 Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE for details.
@@ -11,7 +10,6 @@ import base64
 import random
 import binascii
 import subprocess
-from io import open
 from . import helpers
 from .aes_cipher import AES256Cipher
 from .exceptions import JakException, WrongKeyException
@@ -29,8 +27,8 @@ def _create_local_remote_diff_files(filepath, local, remote):
     """
     tag = random.randrange(10000, 99999)
     (filepath, ext) = os.path.splitext(filepath)
-    local_file_path = '{}_LOCAL_{}{}'.format(filepath, tag, ext)
-    remote_file_path = '{}_REMOTE_{}{}'.format(filepath, tag, ext)
+    local_file_path = f'{filepath}_LOCAL_{tag}{ext}'
+    remote_file_path = f'{filepath}_REMOTE_{tag}{ext}'
 
     helpers.create_or_overwrite_file(filepath=local_file_path, content=local)
     helpers.create_or_overwrite_file(filepath=remote_file_path, content=remote)
@@ -95,14 +93,14 @@ cyz>
     try:
         decrypted = aes256_cipher.decrypt(ciphertext=ugly_local)
     except WrongKeyException as wke:
-        raise JakException('LOCAL - {}'.format(wke.__str__()))
+        raise JakException(f'LOCAL - {wke.__str__()}')
     else:
         secrets.append(decrypted.decode('utf-8').rstrip('\n'))
 
     try:
         decrypted = aes256_cipher.decrypt(ciphertext=ugly_remote)
     except WrongKeyException as wke:
-        raise JakException('REMOTE - {}'.format(wke.__str__()))
+        raise JakException(f'REMOTE - {wke.__str__()}')
     else:
         secrets.append(decrypted.decode('utf-8').rstrip('\n'))
 
@@ -118,7 +116,7 @@ def _extract_merge_conflict_parts(content):
 @decorators.select_key
 def diff(filepath, key, **kwargs):
     """Diff and merge a file that has a merge conflict."""
-    with open(filepath, 'rt') as f:
+    with open(filepath) as f:
         encrypted_diff_file = f.read()
 
     (header, local, separator, remote, end) = _extract_merge_conflict_parts(encrypted_diff_file)

--- a/jak/helpers.py
+++ b/jak/helpers.py
@@ -7,7 +7,6 @@ import os
 import json
 import errno
 import binascii
-from io import open
 
 
 def grouper(iterable, n):
@@ -61,11 +60,11 @@ def create_backup_filepath(jwd, filepath):
 
     # Special case: root.
     if ('/' not in filename):
-        return '/.jak/{}_backup'.format(filename)
+        return f'/.jak/{filename}_backup'
 
     filename = filename[1:]  # b/c/d
     filename = filename.replace('/', '_')  # b_c_d
-    return '{}/.jak/{}_backup'.format(jwd, filename)  # /a/.jak/b_c_d_backup
+    return f'{jwd}/.jak/{filename}_backup'  # /a/.jak/b_c_d_backup
 
 
 def backup_file_content(jwd, filepath, content):
@@ -92,7 +91,7 @@ def get_backup_content_for_file(jwd, filepath):
     TODO Needs test
     """
     filename = create_backup_filepath(jwd=jwd, filepath=filepath)
-    with open(filename, 'rt') as f:
+    with open(filename) as f:
         encrypted_secret = f.read()
     return encrypted_secret
 
@@ -102,7 +101,7 @@ def two_column(left, right, col1_length=65, col2_length=1):
     Example:
     I did this thing             done!
     """
-    tmp = '%-{}s%-{}s'.format(col1_length, col2_length)
+    tmp = f'%-{col1_length}s%-{col2_length}s'
 
     # The space in front of the right column add minimal padding in case
     # lefts content is very long (>col1_length)
@@ -131,7 +130,7 @@ def get_jak_working_directory(cwd=os.getcwd()):
     if none is found default to current directory: './'"""
 
     # They are probably in a .git repo so let's check that right off the bat.
-    if os.path.exists('{}/.git'.format(cwd)):
+    if os.path.exists(f'{cwd}/.git'):
         return cwd
 
     cwd_path = cwd.split('/')
@@ -146,7 +145,7 @@ def get_jak_working_directory(cwd=os.getcwd()):
     # /A/B/C/.git --> True, returns '/A/B/C'
     for directory in reversed(cwd_path):
         dirpath = '/'.join(cwd_path)
-        if os.path.exists('{}/.git'.format(dirpath)):
+        if os.path.exists(f'{dirpath}/.git'):
             return dirpath
         cwd_path.remove(directory)
 
@@ -157,12 +156,12 @@ def get_jak_working_directory(cwd=os.getcwd()):
 def does_jwd_have_gitignore(cwd=os.getcwd()):
     """'' means they are in repo root."""
     jwd = get_jak_working_directory(cwd=cwd)
-    return os.path.exists('{}/.gitignore'.format(jwd))
+    return os.path.exists(f'{jwd}/.gitignore')
 
 
 def read_jakfile_to_dict(jwd=get_jak_working_directory()):
     """Read the jakfile and dump its json comments into a dict for easy usage"""
-    with open('{}/jakfile'.format(jwd), 'rt') as f:
+    with open(f'{jwd}/jakfile') as f:
         contents_raw = f.read()
 
     sans_comments = _remove_comments_from_JSON(contents_raw)

--- a/jak/outputs.py
+++ b/jak/outputs.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 Copyright 2021 Dispel, LLC
 Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE for details.
 """
 
-FRESH_JAKFILE = u'''
+FRESH_JAKFILE = '''
 {{
 
   // This list is for the encrypt/decrypt all commands and for the

--- a/jak/padding.py
+++ b/jak/padding.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Copyright 2021 Dispel, LLC
 Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE for details.

--- a/jak/start.py
+++ b/jak/start.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Copyright 2021 Dispel, LLC
 Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE for details.
@@ -6,15 +5,14 @@ Apache 2.0 License, see https://github.com/dispel/jak/blob/master/LICENSE for de
 
 import os
 import click
-from io import open
 from . import outputs
 from . import helpers
 
 
 def create_jakfile(jwd=os.getcwd()):
     """Create a jakfile if you do not already have one in your JWD"""
-    jakfile_path = '{}/jakfile'.format(jwd)
-    keyfile_path = '{}/.jak/keyfile'.format(jwd)
+    jakfile_path = f'{jwd}/jakfile'
+    keyfile_path = f'{jwd}/.jak/keyfile'
 
     if os.path.exists(jakfile_path):
         msg = helpers.two_column('Is there already a jakfile?', 'Yep!')
@@ -25,8 +23,8 @@ def create_jakfile(jwd=os.getcwd()):
         helpers.create_or_overwrite_file(filepath=jakfile_path, content=fresh_jakfile)
         helpers.create_or_overwrite_file(filepath=keyfile_path, content=key)
         msg = helpers.two_column('Is there already a jakfile?', 'Nope!')
-        msg += '\n' + helpers.two_column('  Creating {}'.format(jakfile_path), 'Done')
-        msg += '\n' + helpers.two_column('  Creating {}'.format(keyfile_path), 'Done')
+        msg += '\n' + helpers.two_column(f'  Creating {jakfile_path}', 'Done')
+        msg += '\n' + helpers.two_column(f'  Creating {keyfile_path}', 'Done')
     return msg + '\n'
 
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 from jak import helpers
 from Crypto.Cipher import AES

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import pytest
 from jak import decorators

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import jak.diff as difflib
 from jak.exceptions import JakException
 import pytest
@@ -59,14 +57,14 @@ PL2gvlgTqLxOzupXgA==
     ('env.yaml', 'env_LOCAL_1232342.yaml', 'env_REMOTE_1232342.yaml')
 ])
 def test_smoke_vimdiff(f, lf, rf):
-    expected = "vimdiff -f -d -c 'wincmd J' {} {} {}".format(f, lf, rf)
+    expected = f"vimdiff -f -d -c 'wincmd J' {f} {lf} {rf}"
     assert expected in difflib._vimdiff(f, lf, rf)
 
 
 @pytest.mark.parametrize('filepath,name,local,remote', [
     ('a', 'b', 'c', 'd'),
     ('', 'env.yaml', 'localcontent', 'remotecontent'),
-    ('a/real/path', 'env.ext', u'localcontent', u'remotecontent')
+    ('a/real/path', 'env.ext', 'localcontent', 'remotecontent')
 ])
 def test_create_local_remote_diff_files(tmpdir, filepath, name, local, remote):
     # create a folder for them to put the files so we dont pollute.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 from jak import helpers
 

--- a/tests/test_jak.py
+++ b/tests/test_jak.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 from click.testing import CliRunner
 from jak.app import main as jak

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -24,7 +24,7 @@ def test_add_keyfile_to_gitignore(tmpdir):
     gitignore = tmpdir.join('.gitignore')
     gitignore.write('# Simple Git Ignore')
     start.add_keyfile_to_gitignore(gitignore.strpath)
-    with open(gitignore.strpath, 'r') as f:
+    with open(gitignore.strpath) as f:
         new_gitignore = f.read()
     assert '.jak' in new_gitignore
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ envlist=
 
 [testenv]
 usedevelop=true
-commands=py.test --cov jak {posargs}
+commands=pytest --cov jak {posargs}
 deps=
     lowest: click==6.6
     lowest: pycryptodome==3.10.1


### PR DESCRIPTION
Re: https://github.com/dispel/jak/pull/60#discussion_r695552908

Based on and targetting the `remove-compat` branch.

Using https://github.com/asottile/pyupgrade/ with `--py36-plus`.

Also drop the dot in `py.test`: https://twitter.com/pytestdotorg/status/753767547866972160"